### PR TITLE
fix: throw code as BiometryError

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -33,8 +33,8 @@ export abstract class BiometricAuthBase
       if (error instanceof CapacitorException) {
         throw new BiometryError(
           error.message,
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- error.data values are typed as any
-          error.data!.code as BiometryErrorType,
+          // error.code is typed as ExceptionCode, but should accept BiometryErrorType.
+          error.code as unknown as BiometryErrorType,
         )
       } else {
         throw error


### PR DESCRIPTION
`error.data.code` throws `TypeError` when an exception is thrown by the native platforms. Happens in v6.0.0.
