### PR TITLE
fix: add .js extensions to relative imports for ESM compatibility

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -8,8 +8,8 @@ import type {
   BiometryType,
   CheckBiometryResult,
   ResumeListener,
-} from './definitions'
-import { BiometryError, isBiometryErrorType } from './definitions'
+} from './definitions.js'
+import { BiometryError, isBiometryErrorType } from './definitions.js'
 
 export abstract class BiometricAuthBase
   extends WebPlugin

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,22 @@
 import { registerPlugin } from '@capacitor/core'
 
-import type { BiometricAuthPlugin } from './definitions'
+import type { BiometricAuthPlugin } from './definitions.js'
 
 const proxy = registerPlugin<BiometricAuthPlugin>('BiometricAuthNative', {
   web: async () => {
-    const module = await import('./web')
+    const module = await import('./web.js')
     return new module.BiometricAuthWeb()
   },
   ios: async () => {
-    const module = await import('./native')
+    const module = await import('./native.js')
     return new module.BiometricAuthNative(proxy)
   },
   android: async () => {
-    const module = await import('./native')
+    const module = await import('./native.js')
     return new module.BiometricAuthNative(proxy)
   },
 })
 
-export * from './definitions'
-export * from './web-utils'
+export * from './definitions.js'
+export * from './web-utils.js'
 export { proxy as BiometricAuth }

--- a/src/native.ts
+++ b/src/native.ts
@@ -1,10 +1,10 @@
-import { BiometricAuthBase } from './base'
+import { BiometricAuthBase } from './base.js'
 import type {
   AuthenticateOptions,
   BiometricAuthPlugin,
   CheckBiometryResult,
-} from './definitions'
-import { BiometryErrorType, BiometryType } from './definitions'
+} from './definitions.js'
+import { BiometryErrorType, BiometryType } from './definitions.js'
 
 /* eslint-disable @typescript-eslint/class-methods-use-this, @typescript-eslint/require-await */
 

--- a/src/web-utils.ts
+++ b/src/web-utils.ts
@@ -1,4 +1,4 @@
-import { BiometryType } from './definitions'
+import { BiometryType } from './definitions.js'
 
 const kBiometryTypeNameMap = {
   [BiometryType.none]: '',

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,7 +1,7 @@
-import { BiometricAuthBase } from './base'
-import type { AuthenticateOptions, CheckBiometryResult } from './definitions'
-import { BiometryError, BiometryErrorType, BiometryType } from './definitions'
-import { getBiometryName } from './web-utils'
+import { BiometricAuthBase } from './base.js'
+import type { AuthenticateOptions, CheckBiometryResult } from './definitions.js'
+import { BiometryError, BiometryErrorType, BiometryType } from './definitions.js'
+import { getBiometryName } from './web-utils.js'
 
 /* eslint-disable @typescript-eslint/require-await */
 


### PR DESCRIPTION
## Summary

Node.js ESM requires fully specified imports with file extensions. The current build output uses extensionless imports (e.g., `import './web'`) which fail in strict ESM environments like webpack 5+ with `fullySpecified: true`.

This adds `.js` extensions to all relative imports in the TypeScript source files:
- `src/index.ts`
- `src/base.ts`
- `src/native.ts`
- `src/web.ts`
- `src/web-utils.ts`

TypeScript preserves these extensions in the compiled output, making the ESM build compatible with strict module resolution.

## Test plan

- [x] `pnpm builder` completes successfully
- [x] Verified `dist/esm/index.js` contains `.js` extensions on relative imports

Fixes #57